### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,4 +1022,4 @@ For any questions or feedback, please reach out to us at [dongguanting@ruc.edu.c
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dongguanting/ARPO&type=Date)](https://www.star-history.com/#dongguanting/ARPO&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dongguanting/ARPO&type=Date)](https://star-history.dera.page/#dongguanting/ARPO&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken, so this change points it to a working alternative to restore the chart.